### PR TITLE
pass fn in call to straight_thread()

### DIFF
--- a/threadlib.scad
+++ b/threadlib.scad
@@ -33,6 +33,7 @@ module thread(designator, turns, higbee_arc=20, fn=120, table=THREAD_TABLE)
         higbee_arc=higbee_arc,
         r=Rrotation,
         turns=turns,
+        fn=fn,
         pitch=P);
 }
 


### PR DESCRIPTION
Addressing issue #46: "fn needs to be passed in call to straight_thread()".
I just added the missing "fn=fn," line 36. That should take care of the issue.
I tested locally and it seems to be fine, now specifying fn in bolt(), nut() and tap() work as expected.